### PR TITLE
Add Python graphviz

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - dask[complete]
   - pytest
   - matplotlib
-  - graphviz
+  - python-graphviz
   - jupyterlab
 


### PR DESCRIPTION
`graphviz` does not install the Python bindings, I need `python-graphviz` to get `dask.visualize` to work